### PR TITLE
Screenshot and CSV downloads added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The framework is extensible and modular, allowing use with other timetable struc
 - Google OAuth
   - [Enable APIs](https://developers.google.com/identity/protocols/oauth2/web-server#enable-apis)
   - [Create credentials](https://developers.google.com/identity/protocols/oauth2/web-server#creatingcred)
-    - Under redirect URIs, you want to add `http://localhost:3001/auth/google/redirect`
+    - Under redirect URIs, you want to add `http://localhost:3001/auth/google/callback`
 - Backend
   - run ```npm i```
   - create a `.env` file

--- a/README.md
+++ b/README.md
@@ -16,8 +16,18 @@ The framework is extensible and modular, allowing use with other timetable struc
 ## Setting Up:
 - Install Node, Mongo
 - Run ```mongod``` in a terminal somewhere (Not required if it's running as a service)
+- Google OAuth
+  - [Enable APIs](https://developers.google.com/identity/protocols/oauth2/web-server#enable-apis)
+  - [Create credentials](https://developers.google.com/identity/protocols/oauth2/web-server#creatingcred)
+    - Under redirect URIs, you want to add `http://localhost:3001/auth/google/redirect`
 - Backend
   - run ```npm i```
+  - create a `.env` file
+  - Add the ID and Secret you got from OAuth in the `.env` file
+  - ```
+    NODE_GOOGLE_CLIENT_ID=<Your Client ID>
+    NODE_GOOGLE_CLIENT_SECRET=<Your Client Secret>
+    ```
   - run ```node server.js```
 - Client
   - run ```npm i```

--- a/client/src/components/Timetable/Timetable.tsx
+++ b/client/src/components/Timetable/Timetable.tsx
@@ -9,7 +9,7 @@ import TimetableBody from './TimetableBody';
 import styles from '../../css/Timetable.module.scss';
 
 const MobileTimetable = memo(() => (
-	<Container className={styles.timetableContainer}>
+	<Container className={styles.timetableContainer} id='timetable'>
 		<FaSun className={styles.morningIcon} size="2x" color="yellow" />
 		<table className={styles.timetableA}>
 			<TimetableHeader isMobile />
@@ -31,7 +31,7 @@ const MobileTimetable = memo(() => (
 
 const DesktopTimetable = memo(() => (
 	<Container className={styles.timetableContainer} fluid>
-		<table className={styles.timetable}>
+		<table className={styles.timetable} id='timetable'>
 			<TimetableHeader />
 			<TimetableBody />
 		</table>

--- a/client/src/components/TimetableSwitcher/TimetableSwitcher.tsx
+++ b/client/src/components/TimetableSwitcher/TimetableSwitcher.tsx
@@ -2,8 +2,10 @@ import React, { useState, memo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Dropdown, ButtonGroup, Button } from 'react-bootstrap';
 import {
-	FaTrashAlt, FaPlusSquare, FaPen, FaCopy,
+	FaTrashAlt, FaPlusSquare, FaPen, FaCopy, FaDownload, FaFileDownload
 } from 'react-icons/fa';
+import domtoimage from 'dom-to-image';
+import { triggerBase64Download } from 'react-base64-downloader';
 
 import styles from '../../css/TimetableSwitcher.module.scss';
 
@@ -16,6 +18,7 @@ import {
 	renameTimetable,
 	copyTimetable,
 } from '../../reducers/timetable';
+import selectFilteredTimetable from '../../selectors/timetable';
 
 import { RootState } from '../../app/rootReducer';
 
@@ -27,7 +30,10 @@ const TimetableSwitcher = memo(() => {
 	);
 	const activeTimetableName = useSelector(
 		(state: RootState) => state.timetable.active,
-	);
+    );
+    const timetable = useSelector(
+        (state: RootState) => selectFilteredTimetable(state),
+    );
 
 	const [action, setAction] = useState('');
 
@@ -56,7 +62,26 @@ const TimetableSwitcher = memo(() => {
 		if (inputAction === 'Delete') dispatch(removeTimetable());
 		else if (inputAction === action) setAction('');
 		else setAction(inputAction);
-	};
+    };
+    
+    const handleDownload = async () => {
+        const input = document.getElementById('timetable') as HTMLElement;
+        const imgData = await domtoimage.toPng(input)
+        triggerBase64Download(imgData, 'FFCSThingy - Timetable');
+    };
+
+    const handleSaveCourses = async () => {
+        let csv = '';
+        let header = Object.keys(timetable[0]).filter((val, index) => index!==0).join(',');
+        let values = timetable.map(o => Object.values(o).filter((val, index) => index!==0).join(',')).join('\n');
+        csv += header + '\n' + values;
+        console.log(csv);
+        const downloadLink = document.createElement("a");
+        downloadLink.href = 'data:text/csv;charset=utf-8,' + encodeURI(csv);
+        downloadLink.download = "FFCS - courses.csv";
+        downloadLink.target = '_blank';
+        downloadLink.click();
+    };
 
 	const showInput = () => ['New', 'Edit', 'Copy'].includes(action);
 
@@ -130,6 +155,18 @@ const TimetableSwitcher = memo(() => {
 					disabled={activeTimetableName === 'Default'}
 				>
 					<FaTrashAlt />
+				</Button>
+				<Button
+					className={styles.button}
+					onClick={() => handleDownload()}
+				>
+                    <FaDownload />
+				</Button>
+				<Button
+					className={styles.button}
+					onClick={() => handleSaveCourses()}
+				>
+                    <FaFileDownload />
 				</Button>
 
 			</ButtonGroup>

--- a/client/src/css/Timetable.module.scss
+++ b/client/src/css/Timetable.module.scss
@@ -3,6 +3,7 @@
 	font-size: 0.6em;
 
 	margin-top: 1rem;
+    padding-bottom: 2rem;
 	padding-right: 1rem;
 	padding-left: 1rem !important;
 	

--- a/client/src/types/react-base64-downloader.d.ts
+++ b/client/src/types/react-base64-downloader.d.ts
@@ -1,0 +1,1 @@
+declare module "react-base64-downloader";


### PR DESCRIPTION
# Details
* This PR aims to resolve #74 .
* It provides two buttons in the UI component just before the timetable, that allows the users to download the PNG image of timetable, and a CSV record of the selected courses.

# Updated UI
![1](https://user-images.githubusercontent.com/36758947/97050456-0270e780-159b-11eb-93d6-a203be44faf4.png)

# CSV file
![Screenshot from 2020-10-24 01-39-37](https://user-images.githubusercontent.com/36758947/97050553-33e9b300-159b-11eb-9434-13ee4c04f691.png)

# Screenshots Captured
* Desktop version:
![FFCSThingy - Timetable](https://user-images.githubusercontent.com/36758947/97050494-174d7b00-159b-11eb-9e26-61d8ca36633b.png)

* Mobile version:
![FFCSThingy - Timetable (1)](https://user-images.githubusercontent.com/36758947/97050517-22081000-159b-11eb-981f-1e8fb19555db.png)
